### PR TITLE
Restore Jest tests and config removed by refactor merge

### DIFF
--- a/__mocks__/next/navigation.js
+++ b/__mocks__/next/navigation.js
@@ -1,0 +1,4 @@
+const push = jest.fn();
+const useRouter = () => ({ push });
+const usePathname = () => '/';
+module.exports = { useRouter, usePathname };

--- a/__tests__/CampusMapView.test.jsx
+++ b/__tests__/CampusMapView.test.jsx
@@ -1,0 +1,74 @@
+/**
+ * Tests:
+ * - Campus SVG loads
+ * - Click on academic building navigates to /building/[id]
+ * - Click on student housing shows “not available” error popup
+ */
+
+import React from 'react';
+
+// ---- Stable Next.js router mock ----
+var mockPush; // use var to avoid temporal dead zone
+jest.mock('next/navigation', () => {
+  const actual = jest.requireActual('next/navigation');
+  mockPush = jest.fn();
+  return {
+    ...actual,
+    useRouter: () => ({ push: mockPush }),
+  };
+});
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CampusMapView from '../components/CampusMapView';
+
+beforeEach(() => {
+  mockPush.mockClear();
+
+  const svg = `
+    <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" data-map-anchor>
+      <g id="B" class="building-group">
+        <rect id="B" class="building" x="10" y="10" width="30" height="30" />
+        <text x="25" y="25">B</text>
+      </g>
+      <g id="1000" class="building-group student-housing">
+        <rect id="1000" class="building" x="60" y="10" width="30" height="30" />
+        <text x="75" y="25">Housing</text>
+      </g>
+    </svg>
+  `;
+
+  global.fetch = jest.fn(() =>
+    Promise.resolve({ ok: true, text: () => Promise.resolve(svg) })
+  );
+});
+
+afterEach(() => {
+  delete global.fetch;
+});
+
+test('loads campus SVG and clicking academic building navigates', async () => {
+  render(<CampusMapView />);
+  await waitFor(() => expect(document.querySelector('svg')).toBeInTheDocument());
+
+  const buildingBGroup = document.querySelector('g#B.building-group');
+  expect(buildingBGroup).toBeTruthy();
+  await userEvent.click(buildingBGroup);
+
+  expect(mockPush).toHaveBeenCalledWith('/building/B');
+});
+
+test('clicking student housing shows error popup (blocked)', async () => {
+  render(<CampusMapView />);
+  await waitFor(() => expect(document.querySelector('svg')).toBeInTheDocument());
+
+  const housingRect = document.querySelector('g.student-housing .building');
+  expect(housingRect).toBeTruthy();
+
+  await userEvent.click(housingRect);
+  expect(mockPush).not.toHaveBeenCalled();
+
+  expect(screen.getByText(/student housing layouts/i)).toBeInTheDocument();
+  await userEvent.click(screen.getByRole('button', { name: /ok/i }));
+  expect(screen.queryByText(/student housing layouts/i)).not.toBeInTheDocument();
+});

--- a/__tests__/Find.test.jsx
+++ b/__tests__/Find.test.jsx
@@ -1,0 +1,58 @@
+import React from 'react';
+
+// ---- Stable Next.js router mock ----
+var mockPush; // use var to avoid temporal dead zone
+jest.mock('next/navigation', () => {
+  const actual = jest.requireActual('next/navigation');
+  mockPush = jest.fn();
+  return {
+    ...actual,
+    useRouter: () => ({ push: mockPush }),
+  };
+});
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Find from '../components/Find';
+
+beforeEach(() => {
+  mockPush.mockClear();
+});
+
+async function typeAndFind(value) {
+  const input = screen.getByRole('textbox', { name: /find:/i });
+  const btn = screen.getByRole('button', { name: /find/i });
+  await userEvent.clear(input);
+  await userEvent.type(input, value);
+  await userEvent.click(btn);
+}
+
+test('empty search shows validation', async () => {
+  render(<Find />);
+  await userEvent.click(screen.getByRole('button', { name: /find/i }));
+  expect(screen.getByText(/you must enter a search term/i)).toBeInTheDocument();
+});
+
+test('building search "b" routes to building B L1', async () => {
+  render(<Find />);
+  await typeAndFind('b');
+  expect(mockPush).toHaveBeenCalledWith('/building/B/L1');
+});
+
+test('floor search "b2" routes to /building/B/L2', async () => {
+  render(<Find />);
+  await typeAndFind('b2');
+  expect(mockPush).toHaveBeenCalledWith('/building/B/L2');
+});
+
+test('alias "aec" routes to W/L1 with room=1160', async () => {
+  render(<Find />);
+  await typeAndFind('aec');
+  expect(mockPush).toHaveBeenCalledWith('/building/W/L1?room=1160');
+});
+
+test('invalid search shows "<term> is not valid"', async () => {
+  render(<Find />);
+  await typeAndFind('zz999');
+  expect(screen.getByText(/zz999 is not valid/i)).toBeInTheDocument();
+});

--- a/__tests__/FloorMapView.test.jsx
+++ b/__tests__/FloorMapView.test.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import FloorMapView from '../components/FloorMapView';
+
+beforeEach(() => {
+  jest.resetAllMocks();
+
+  const svg = `
+    <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+      <g id="B-2210" class="room-group">
+        <rect class="room" x="10" y="10" width="30" height="20"/>
+        <text class="label" x="12" y="24">2210</text>
+      </g>
+    </svg>
+  `;
+  global.fetch = jest.fn(() =>
+    Promise.resolve({ ok: true, text: () => Promise.resolve(svg) })
+  );
+});
+
+test('loads floor svg and activates room on click', async () => {
+  render(<FloorMapView src="/fake.svg" />);
+  await waitFor(() => expect(document.querySelector('svg')).toBeInTheDocument());
+  const room = document.querySelector('g.room-group');
+  await userEvent.click(room);
+  expect(room).toHaveClass('active-room');
+});

--- a/__tests__/LayoutSmoke.test.jsx
+++ b/__tests__/LayoutSmoke.test.jsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// Top-level pieces (same ones used by app/layout.js)
+import Header from '../components/Header';
+import Sidebar from '../components/Sidebar';
+import Legend from '../components/legend';
+import Links from '../components/Links';
+import Footer from '../components/Footer';
+
+// Next router is used by multiple components
+jest.mock('next/navigation', () => {
+  const push = jest.fn();
+  return { useRouter: () => ({ push }), usePathname: () => '/' };
+});
+
+//const React = require('react');
+
+jest.mock('next/image', () => {
+  const React = require('react');
+  return function Image(props) {
+    return React.createElement('img', props);
+  };
+});
+
+
+function RenderLayout() {
+  return (
+    <div>
+      <Header />
+      <div className="layout-columns">
+        <Sidebar />
+        <main role="main" className="layout-main">
+          <div>Mock Main Content</div>
+        </main>
+        <div className="layout-rail">
+          <Legend className="mb-4" />
+          <Links />
+        </div>
+      </div>
+      <Footer />
+    </div>
+  );
+}
+
+describe('Layout smoke test', () => {
+  test('renders header, sidebar, legend, links, footer', () => {
+    render(<RenderLayout />);
+
+    // Header
+    expect(screen.getByText(/ggc maps/i)).toBeInTheDocument();
+    // Find input in header
+    expect(screen.getByRole('textbox', { name: /find:/i })).toBeInTheDocument();
+
+    // Sidebar
+    expect(screen.getByRole('navigation', { name: /campus navigation/i })).toBeInTheDocument();
+    expect(screen.getByText(/explore campus/i)).toBeInTheDocument();
+
+    // Legend + Links panels
+    expect(screen.getByText(/^legend$/i)).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /helpful links/i })).toBeInTheDocument();
+
+    // Footer (year text exists)
+    expect(screen.getByText(/Team Lost/i)).toBeInTheDocument();
+  });
+
+  test('sidebar collapse/expand toggles', async () => {
+    render(<RenderLayout />);
+
+    // Collapse button closes sidebar
+    const collapseBtn = screen.getByRole('button', { name: /collapse sidebar navigation/i });
+    await userEvent.click(collapseBtn);
+
+    // Now only the expand toggle remains
+    const expandBtn = screen.getByRole('button', { name: /expand sidebar navigation/i });
+    expect(expandBtn).toBeInTheDocument();
+
+    // Expand back
+    await userEvent.click(expandBtn);
+    expect(screen.getByRole('navigation', { name: /campus navigation/i })).toBeInTheDocument();
+  });
+
+  test('legend collapses and expands', async () => {
+    render(<RenderLayout />);
+    // Title is visible initially
+    expect(screen.getByText(/^legend$/i)).toBeInTheDocument();
+
+    // Collapse (button title toggles between Hide/Show legend)
+    const toggle = screen.getByTitle(/legend/i);
+    await userEvent.click(toggle);
+
+    // Hidden body: the "Legend" title may still be present, but aria-expanded should flip
+    expect(screen.getByTitle(/legend/i)).toHaveAttribute('aria-expanded', 'false');
+
+    // Expand again
+    await userEvent.click(screen.getByTitle(/legend/i));
+    expect(screen.getByTitle(/legend/i)).toHaveAttribute('aria-expanded', 'true');
+  });
+});

--- a/__tests__/Legend.test.jsx
+++ b/__tests__/Legend.test.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Legend from '../components/legend';
+
+function getToggleBtn() {
+  return screen.getByTitle(/legend/i);
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+test('legend renders and collapses/expands', async () => {
+  render(<Legend />);
+  expect(screen.getByText(/^legend$/i)).toBeInTheDocument();
+
+  const collapseBtn = getToggleBtn();
+  expect(collapseBtn).toHaveAttribute('aria-expanded', 'true');
+  await userEvent.click(collapseBtn);
+  expect(getToggleBtn()).toHaveAttribute('aria-expanded', 'false');
+});
+
+test('language toggle switches to ES and persists', async () => {
+  render(<Legend />);
+  const btnES = screen.getByRole('button', { name: /es/i });
+  await userEvent.click(btnES);
+  expect(screen.getByText(/edificio acad/i)).toBeInTheDocument();
+
+  render(<Legend />);
+ expect(screen.getAllByText(/edificio acad/i)[0]).toBeInTheDocument();
+});
+
+test('hover dispatches custom events', async () => {
+  const spy = jest.spyOn(window, 'dispatchEvent');
+  render(<Legend />);
+  const academicRow = screen.getByText(/academic building|edificio acad/i).closest('li');
+  await userEvent.hover(academicRow);
+  expect(spy).toHaveBeenCalledWith(expect.objectContaining({ type: 'ggcmap-hover' }));
+  await userEvent.unhover(academicRow);
+  expect(spy).toHaveBeenCalledWith(expect.objectContaining({ type: 'ggcmap-hover-clear' }));
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,21 @@
+// jest.config.js
+module.exports = {
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  moduleNameMapper: {
+    '\\.(css|less|sass|scss)$': 'identity-obj-proxy',
+    '^@/(.*)$': '<rootDir>/$1',
+  },
+  transform: {
+    '^.+\\.(js|jsx)$': [
+      'babel-jest',
+      {
+        presets: [
+          ['@babel/preset-env', { targets: { node: 'current' } }],
+          ['@babel/preset-react', { runtime: 'automatic' }],
+        ],
+      },
+    ],
+  },
+  moduleFileExtensions: ['js', 'jsx', 'json'],
+};

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,49 @@
+// jest.setup.js
+// CommonJS so Jest can parse it without ESM config
+require('@testing-library/jest-dom');
+
+
+jest.mock('next/image', () => {
+  const React = require('react');
+  return {
+    __esModule: true,
+    default: (props) =>
+      React.createElement('img', {
+        ...props,
+        // Next/Image requires alt; default to empty for tests
+        alt: props.alt ?? '',
+      }),
+  };
+});
+
+// (optional) mock router if your tests navigate
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    replace: jest.fn(),
+    prefetch: jest.fn(),
+  }),
+}));
+
+const originalError = console.error;
+const originalDebug = console.debug;
+
+beforeAll(() => {
+  console.error = (...args) => {
+    const msg = String(args[0] ?? '');
+    if (
+      /Warning.*not wrapped in act/i.test(msg) ||
+      /Received `true` for a non-boolean attribute `priority`/i.test(msg) // <- keep this line exactly
+    ) {
+      return;
+    }
+    originalError.call(console, ...args);
+  };
+
+  console.debug = jest.fn();
+});
+
+afterAll(() => {
+  console.error = originalError;
+  console.debug = originalDebug;
+});


### PR DESCRIPTION
This pull request restores the Jest test suite and setup files that were removed during the Oct 30 refactor merge.

✅ Adds back:
- __tests__/
- jest.config.js
- jest.setup.js
- __mocks__/next/navigation.js

🔒 Does not modify application code — only reintroduces testing infrastructure.
